### PR TITLE
Feature/create product update

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -31,3 +31,10 @@ build/
 
 ### VS Code ###
 .vscode/
+
+### imágenes
+*.jpg
+*.jpeg
+*.png
+*.gif
+/uploads/

--- a/pom.xml
+++ b/pom.xml
@@ -70,7 +70,6 @@
 		<dependency>
 			<groupId>com.h2database</groupId>
 			<artifactId>h2</artifactId>
-			<scope>test</scope>
 		</dependency>
 		<dependency>
 			<groupId>org.springframework.boot</groupId>

--- a/src/main/java/com/dh/roomly/controller/PropertyController.java
+++ b/src/main/java/com/dh/roomly/controller/PropertyController.java
@@ -12,6 +12,10 @@ import org.springframework.data.domain.PageRequest;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
+import org.springframework.web.multipart.MultipartFile;
+
+import java.io.IOException;
+import java.util.List;
 
 @RestController
 @RequestMapping("v1/properties")
@@ -26,9 +30,17 @@ public class PropertyController {
         return this.iPropertyService.findAll(filter, PageRequest.of(page, size));
     }
 
+    /*
     @PostMapping("/new")
-    public ResponseEntity<PropertyDTO> createProperty(@Valid @RequestBody PropertyDTO dto) {
-        PropertyDTO createdProperty = iPropertyService.createProperty(dto);
+    public PropertyDTO createProperty(@Valid @RequestBody PropertyDTO dto){
+        return iPropertyService.createProperty(dto);
+    }
+    */
+
+    @PostMapping("/new")
+    public ResponseEntity<PropertyDTO> createPropertyWithPhotos(@Valid @RequestPart("propertyDTO") PropertyDTO dto,
+                                                                @RequestParam("files") List<MultipartFile> images) throws IOException {
+        PropertyDTO createdProperty = iPropertyService.createPropertyWithPhotos(dto, images);
         return ResponseEntity.status(HttpStatus.CREATED).body(createdProperty);
     }
 

--- a/src/main/java/com/dh/roomly/controller/PropertyController.java
+++ b/src/main/java/com/dh/roomly/controller/PropertyController.java
@@ -2,6 +2,7 @@ package com.dh.roomly.controller;
 
 import com.dh.roomly.dto.impl.PropertyDTO;
 import com.dh.roomly.dto.filter.PropertyFilterDTO;
+import com.dh.roomly.exception.MissingImageException;
 import com.dh.roomly.service.IPropertyService;
 import jakarta.validation.Valid;
 import jakarta.validation.constraints.Max;
@@ -30,16 +31,12 @@ public class PropertyController {
         return this.iPropertyService.findAll(filter, PageRequest.of(page, size));
     }
 
-    /*
-    @PostMapping("/new")
-    public PropertyDTO createProperty(@Valid @RequestBody PropertyDTO dto){
-        return iPropertyService.createProperty(dto);
-    }
-    */
-
     @PostMapping("/new")
     public ResponseEntity<PropertyDTO> createPropertyWithPhotos(@Valid @RequestPart("propertyDTO") PropertyDTO dto,
                                                                 @RequestParam("files") List<MultipartFile> images) throws IOException {
+        if (images == null || images.isEmpty() || images.stream().allMatch(MultipartFile::isEmpty)) {
+            throw new MissingImageException("At least one non-empty image must be provided.");
+        }
         PropertyDTO createdProperty = iPropertyService.createPropertyWithPhotos(dto, images);
         return ResponseEntity.status(HttpStatus.CREATED).body(createdProperty);
     }

--- a/src/main/java/com/dh/roomly/controller/PropertyController.java
+++ b/src/main/java/com/dh/roomly/controller/PropertyController.java
@@ -9,6 +9,8 @@ import jakarta.validation.constraints.Min;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.PageRequest;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
 
 @RestController
@@ -25,8 +27,9 @@ public class PropertyController {
     }
 
     @PostMapping("/new")
-    public PropertyDTO createProperty(@Valid @RequestBody PropertyDTO dto){
-        return iPropertyService.createProperty(dto);
+    public ResponseEntity<PropertyDTO> createProperty(@Valid @RequestBody PropertyDTO dto) {
+        PropertyDTO createdProperty = iPropertyService.createProperty(dto);
+        return ResponseEntity.status(HttpStatus.CREATED).body(createdProperty);
     }
 
 }

--- a/src/main/java/com/dh/roomly/entity/FileEntity.java
+++ b/src/main/java/com/dh/roomly/entity/FileEntity.java
@@ -1,0 +1,19 @@
+package com.dh.roomly.entity;
+
+import jakarta.persistence.*;
+import lombok.AllArgsConstructor;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+@Entity
+@Data
+@AllArgsConstructor
+@NoArgsConstructor
+@Table(name = "file")
+public class FileEntity {
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+    private String name;
+    private String url;
+}

--- a/src/main/java/com/dh/roomly/entity/PropertyEntity.java
+++ b/src/main/java/com/dh/roomly/entity/PropertyEntity.java
@@ -10,6 +10,8 @@ import lombok.experimental.SuperBuilder;
 import jakarta.persistence.*;
 
 import java.math.BigDecimal;
+import java.util.ArrayList;
+import java.util.List;
 
 @Getter
 @Setter
@@ -56,4 +58,12 @@ public class PropertyEntity {
 
     @Column(name = "CATEGORY_ID", nullable = false)
     private Short categoryId;
+
+    @ManyToMany(cascade = {CascadeType.PERSIST, CascadeType.MERGE})
+    @JoinTable(
+            name = "property_photo",
+            joinColumns = @JoinColumn(name = "property_id"),
+            inverseJoinColumns = @JoinColumn(name = "file_id")
+    )
+    private List<FileEntity> photos = new ArrayList<>();
 }

--- a/src/main/java/com/dh/roomly/exception/DuplicateResourceException.java
+++ b/src/main/java/com/dh/roomly/exception/DuplicateResourceException.java
@@ -1,0 +1,11 @@
+package com.dh.roomly.exception;
+
+import org.springframework.http.HttpStatus;
+import org.springframework.web.bind.annotation.ResponseStatus;
+
+@ResponseStatus(HttpStatus.CONFLICT)
+public class DuplicateResourceException extends RuntimeException {
+  public DuplicateResourceException(String message) {
+    super(message);
+  }
+}

--- a/src/main/java/com/dh/roomly/exception/GlobalExceptionHandler.java
+++ b/src/main/java/com/dh/roomly/exception/GlobalExceptionHandler.java
@@ -16,6 +16,7 @@ import org.springframework.web.bind.MethodArgumentNotValidException;
 import org.springframework.web.bind.annotation.ControllerAdvice;
 import org.springframework.web.bind.annotation.ExceptionHandler;
 import org.springframework.web.context.request.WebRequest;
+import org.springframework.web.multipart.MultipartException;
 
 @Slf4j
 @ControllerAdvice
@@ -79,6 +80,26 @@ public class GlobalExceptionHandler {
 
     @ExceptionHandler(DuplicateResourceException.class)
     public ResponseEntity<Object> handleDuplicateResourceException(DuplicateResourceException exception, WebRequest request) {
-        return new ResponseEntity<>(this.buildSingleErrorDetailsDTO(exception, request), HttpStatus.BAD_REQUEST);
+        return new ResponseEntity<>(this.buildSingleErrorDetailsDTO(exception, request), HttpStatus.CONFLICT);
     }
+
+    @ExceptionHandler(MissingImageException.class)
+    public ResponseEntity<Object> handleMissingImageException(MissingImageException exception, WebRequest request) {
+        return new ResponseEntity<>(ErrorDetailsDTO.builder()
+                .timestamp(LocalDateTime.now())
+                .details(List.of(exception.getMessage()))
+                .message(request.getDescription(false))
+                .build(), HttpStatus.BAD_REQUEST);
+    }
+
+    @ExceptionHandler(MultipartException.class)
+    public ResponseEntity<Object> handleMultipartException(MultipartException exception, WebRequest request) {
+        return new ResponseEntity<>(ErrorDetailsDTO.builder()
+                .timestamp(LocalDateTime.now())
+                .details(List.of("File upload error", exception.getMessage()))
+                .message("Multipart request could not be processed.")
+                .build(), HttpStatus.BAD_REQUEST);
+    }
+
+
 }

--- a/src/main/java/com/dh/roomly/exception/GlobalExceptionHandler.java
+++ b/src/main/java/com/dh/roomly/exception/GlobalExceptionHandler.java
@@ -76,4 +76,9 @@ public class GlobalExceptionHandler {
                 .message(request.getDescription(Boolean.FALSE))
                 .build();
     }
+
+    @ExceptionHandler(DuplicateResourceException.class)
+    public ResponseEntity<Object> handleDuplicateResourceException(DuplicateResourceException exception, WebRequest request) {
+        return new ResponseEntity<>(this.buildSingleErrorDetailsDTO(exception, request), HttpStatus.BAD_REQUEST);
+    }
 }

--- a/src/main/java/com/dh/roomly/exception/MissingImageException.java
+++ b/src/main/java/com/dh/roomly/exception/MissingImageException.java
@@ -1,0 +1,7 @@
+package com.dh.roomly.exception;
+
+public class MissingImageException extends RuntimeException {
+    public MissingImageException(String message) {
+        super(message);
+    }
+}

--- a/src/main/java/com/dh/roomly/repository/IFileRepository.java
+++ b/src/main/java/com/dh/roomly/repository/IFileRepository.java
@@ -1,0 +1,7 @@
+package com.dh.roomly.repository;
+
+import com.dh.roomly.entity.FileEntity;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface IFileRepository extends JpaRepository<FileEntity, Long> {
+}

--- a/src/main/java/com/dh/roomly/repository/IPropertyRepository.java
+++ b/src/main/java/com/dh/roomly/repository/IPropertyRepository.java
@@ -7,4 +7,5 @@ import org.springframework.stereotype.Repository;
 
 @Repository
 public interface IPropertyRepository extends JpaRepository<PropertyEntity, String>, JpaSpecificationExecutor<PropertyEntity> {
+    boolean existsByName(String name);
 }

--- a/src/main/java/com/dh/roomly/service/IFileService.java
+++ b/src/main/java/com/dh/roomly/service/IFileService.java
@@ -1,0 +1,11 @@
+package com.dh.roomly.service;
+
+import com.dh.roomly.entity.FileEntity;
+import org.springframework.web.multipart.MultipartFile;
+
+import java.io.IOException;
+import java.util.List;
+
+public interface IFileService {
+    List<FileEntity> saveFiles(List<MultipartFile> files) throws IOException;
+}

--- a/src/main/java/com/dh/roomly/service/IPropertyService.java
+++ b/src/main/java/com/dh/roomly/service/IPropertyService.java
@@ -3,7 +3,6 @@ package com.dh.roomly.service;
 import com.dh.roomly.dto.impl.PropertyDTO;
 import com.dh.roomly.dto.filter.PropertyFilterDTO;
 import jakarta.transaction.Transactional;
-import jakarta.validation.Valid;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.web.multipart.MultipartFile;
@@ -14,8 +13,6 @@ import java.util.List;
 public interface IPropertyService {
 
     Page<PropertyDTO> findAll(PropertyFilterDTO filter, Pageable pageable);
-
-    PropertyDTO createProperty(PropertyDTO dto);
 
     @Transactional
     PropertyDTO createPropertyWithPhotos(PropertyDTO propertyDTO, List<MultipartFile> files) throws IOException;

--- a/src/main/java/com/dh/roomly/service/IPropertyService.java
+++ b/src/main/java/com/dh/roomly/service/IPropertyService.java
@@ -2,13 +2,21 @@ package com.dh.roomly.service;
 
 import com.dh.roomly.dto.impl.PropertyDTO;
 import com.dh.roomly.dto.filter.PropertyFilterDTO;
+import jakarta.transaction.Transactional;
 import jakarta.validation.Valid;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
+import org.springframework.web.multipart.MultipartFile;
+
+import java.io.IOException;
+import java.util.List;
 
 public interface IPropertyService {
 
     Page<PropertyDTO> findAll(PropertyFilterDTO filter, Pageable pageable);
 
-    PropertyDTO createProperty(@Valid PropertyDTO dto);
+    PropertyDTO createProperty(PropertyDTO dto);
+
+    @Transactional
+    PropertyDTO createPropertyWithPhotos(PropertyDTO propertyDTO, List<MultipartFile> files) throws IOException;
 }

--- a/src/main/java/com/dh/roomly/service/impl/LocalFileServiceImpl.java
+++ b/src/main/java/com/dh/roomly/service/impl/LocalFileServiceImpl.java
@@ -1,0 +1,45 @@
+package com.dh.roomly.service.impl;
+import com.dh.roomly.entity.FileEntity;
+import com.dh.roomly.service.IFileService;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Service;
+import org.springframework.web.multipart.MultipartFile;
+
+import java.io.File;
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.UUID;
+
+@Service
+public class LocalFileServiceImpl implements IFileService {
+
+    @Value("${upload.directory}")
+    private String uploadDirectory;
+
+    public List<FileEntity> saveFiles(List<MultipartFile> files) throws IOException {
+        List<FileEntity> savedFiles = new ArrayList<>();
+
+        Path directoryPath = Paths.get(uploadDirectory);
+        if (!Files.exists(directoryPath)) {
+            Files.createDirectories(directoryPath);
+        }
+
+        for (MultipartFile file : files) {
+            String fileName = System.currentTimeMillis() + "_" + file.getOriginalFilename();
+            Path filePath = directoryPath.resolve(fileName);
+            Files.write(filePath, file.getBytes());
+
+            FileEntity fileEntity = new FileEntity();
+            fileEntity.setName(fileName);
+            fileEntity.setUrl(filePath.toString());
+
+            savedFiles.add(fileEntity);
+        }
+
+        return savedFiles;
+    }
+}

--- a/src/main/java/com/dh/roomly/service/impl/PropertyService.java
+++ b/src/main/java/com/dh/roomly/service/impl/PropertyService.java
@@ -4,6 +4,7 @@ import com.dh.roomly.dto.common.MappingDTO;
 import com.dh.roomly.dto.impl.PropertyDTO;
 import com.dh.roomly.dto.filter.PropertyFilterDTO;
 import com.dh.roomly.entity.PropertyEntity;
+import com.dh.roomly.exception.DuplicateResourceException;
 import com.dh.roomly.repository.IPropertyRepository;
 import com.dh.roomly.repository.specification.PropertySpecification;
 import com.dh.roomly.service.IPropertyService;
@@ -30,6 +31,9 @@ public class PropertyService implements IPropertyService {
 
     @Override
     public PropertyDTO createProperty(PropertyDTO propertyDTO) {
+        if (iPropertyRepository.existsByName(propertyDTO.getName())) {
+            throw new DuplicateResourceException("El nombre '" + propertyDTO.getName() + "' ya está en uso. Por favor, elige otro nombre.");
+        }
         PropertyEntity property = (PropertyEntity) MappingDTO.convertToEntity(propertyDTO, PropertyEntity.class);
         PropertyEntity savedProperty = iPropertyRepository.save(property);
         return (PropertyDTO) MappingDTO.convertToDto(savedProperty, new PropertyDTO());

--- a/src/main/java/com/dh/roomly/service/impl/PropertyService.java
+++ b/src/main/java/com/dh/roomly/service/impl/PropertyService.java
@@ -41,13 +41,6 @@ public class PropertyService implements IPropertyService {
     }
 
     @Override
-    public PropertyDTO createProperty(PropertyDTO propertyDTO) {
-        PropertyEntity property = (PropertyEntity) MappingDTO.convertToEntity(propertyDTO, PropertyEntity.class);
-        PropertyEntity savedProperty = iPropertyRepository.save(property);
-        return (PropertyDTO) MappingDTO.convertToDto(savedProperty, new PropertyDTO());
-    }
-
-    @Override
     @Transactional
     public PropertyDTO createPropertyWithPhotos(PropertyDTO propertyDTO, List<MultipartFile> files) throws IOException {
         if (iPropertyRepository.existsByName(propertyDTO.getName())) {

--- a/src/main/resources/application.yaml
+++ b/src/main/resources/application.yaml
@@ -7,19 +7,23 @@ spring:
   application:
     name: roomly-services
   datasource:
-    driver-class-name: com.mysql.cj.jdbc.Driver
-    url: ${SPRING_DATASOURCE_URL}
-    username: ${SPRING_DATASOURCE_USERNAME}
-    password: ${SPRING_DATASOURCE_PASSWORD}
+    #    driver-class-name: com.mysql.cj.jdbc.Driver
+    #    url: ${SPRING_DATASOURCE_URL}
+    #    username: ${SPRING_DATASOURCE_USERNAME}
+    #    password: ${SPRING_DATASOURCE_PASSWORD}
+    driver-class-name: org.h2.Driver
+    url: jdbc:h2:mem:testdb
+    username: sa
+    password: sa
 
   mvc:
     pathmatch:
       matching-strategy: ant_path_matcher
   jpa:
     show-sql: true
+    dialect: org.hibernate.dialect.MySQL5InnoDBDialect
     hibernate:
       ddl-auto: create-drop
-      dialect: org.hibernate.dialect.MySQL5InnoDBDialect
       jdbc:
         batch_size: 50
         batch_versioned_data: true

--- a/src/main/resources/application.yaml
+++ b/src/main/resources/application.yaml
@@ -27,3 +27,11 @@ spring:
       order_updates: true
       generate_statistics: false
     open-in-view: false
+  servlet:
+    multipart:
+      enabled: true
+      max-file-size: 10MB
+      max-request-size: 10MB
+
+upload:
+  directory: uploads/images/


### PR DESCRIPTION
Implementa funcionalidad para subir imágenes al crear propiedades

- Añadida lógica para manejar la subida de imágenes en el controlador de propiedades.
- Se implementa la relación muchos a muchos entre Property y FileEntity a través de la tabla intermedia Property_Photo.
- Archivos de imagen se guardan localmente en el directorio uploads.
- Se configura el .gitignore para evitar la subida de archivos de imagen al repositorio.
- Se agrega excepcion MissingImageException para manejar la falta de imágenes en la creación